### PR TITLE
Replace Schema with Truss

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -2,7 +2,7 @@
  :source-paths   #{"src"}
  :dependencies '[[adzerk/bootlaces "0.1.13" :scope "test"]
                  [org.clojure/clojure "1.7.0" :scope "provided"]
-                 [prismatic/schema "1.0.3"]
+                 [com.taoensso/truss "1.5.0"]
                  [amazonica "0.3.57" :exclusions [com.amazonaws/aws-java-sdk]]
                  [com.amazonaws/aws-java-sdk-core "1.10.77"]
                  [com.amazonaws/aws-java-sdk-s3 "1.10.77"]


### PR DESCRIPTION
Hey @ptaoussanis :) — I used schema here previously but Truss seemed like the smaller-footpring & simpler solution. 

The reason I ping you is because I'm not sure about the following

- I have a custom validator `have-file-map`
- I use that validator like `(truss/have have-file-map :in file-maps)`

To me these two levels of `have` seem a bit weird but maybe that's just as intended? 
An alternative would be to have a single predicate-fn but then you would lose the benefits of showing what part of the data is invalid.